### PR TITLE
Add Blood Magic Altar Compatibility to the Hologram projector

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,6 +21,8 @@ dependencies {
         transitive = false
     }
     implementation("com.github.GTNewHorizons:Railcraft:9.15.3:dev")
+    
+    implementation("com.github.GTNewHorizons:BloodMagic:1.5.2:dev")
     // for convenience of debug
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.5.3-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.6.5:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ dependencies {
         transitive = false
     }
     implementation("com.github.GTNewHorizons:Railcraft:9.15.3:dev")
-    
+
     implementation("com.github.GTNewHorizons:BloodMagic:1.5.2:dev")
     // for convenience of debug
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.5.3-GTNH:dev")

--- a/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
+++ b/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
@@ -1,230 +1,158 @@
 package net.glease.structurecompat;
 
-import WayofTime.alchemicalWizardry.ModBlocks;
-import WayofTime.alchemicalWizardry.common.tileEntity.TEAltar;
-
 import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
-import static com.gtnewhorizon.structurelib.structure.StructureUtility.partitionBy;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlockAnyMeta;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofChain;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.transpose;
 
-
-import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
-
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
 import com.gtnewhorizon.structurelib.alignment.constructable.IMultiblockInfoContainer;
 import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
 import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
 import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
 import com.gtnewhorizon.structurelib.structure.StructureDefinition;
 
-import mods.railcraft.common.blocks.RailcraftBlocks;
-import mods.railcraft.common.blocks.machine.beta.EnumMachineBeta;
-
+import WayofTime.alchemicalWizardry.AlchemicalWizardry;
+import WayofTime.alchemicalWizardry.ModBlocks;
+import WayofTime.alchemicalWizardry.common.tileEntity.TEAltar;
 
 @Compat("AWWayofTime")
-public class CompatBloodMagic
-{
-    // (width, height)
-    public static final int[][] BOILER_DIMENSIONS = { { 1, 1 }, { 2, 2 }, { 2, 3 }, { 3, 2 }, { 3, 3 }, { 3, 4 } };
+public class CompatBloodMagic {
 
-    public CompatBloodMagic()
-    {
-        registerBoilerStructureInfo();
+    private static String STRUCTURE_ALTAR = "tier1";
+    private static String STRUCTURE_TIER_2 = "tier2";
+    private static String STRUCTURE_TIER_3 = "tier3";
+    private static String STRUCTURE_TIER_4 = "tier4";
+    private static String STRUCTURE_TIER_5 = "tier5";
+    private static String STRUCTURE_TIER_6 = "tier6";
+
+    public static final int[][] TIER_OFFSET = { { 0, 0, 0 }, { 1, -1, 1 }, { 3, 1, 3 }, { 5, 2, 5 }, { 8, -3, 8 },
+            { 11, 3, 11 } };
+
+    public CompatBloodMagic() {
+        registerAltarStructureInfo();
     }
 
-    private static void registerBoilerStructureInfo() {
-        String solidPrefix = "st";
-        StructureDefinition.Builder<TEAltar> b = IStructureDefinition.builder();
-        int[][] ints = BOILER_DIMENSIONS;
-        for (int i = 0, intsLength = ints.length; i < intsLength; i++) {
-            int[] dimension = ints[i];
-            String[][] shape1 = new String[dimension[1]][];
-            for (int i1 = 0; i1 < dimension[1]; i1++) {
-                shape1[i1] = new String[dimension[0] + 1];
-                for (int i2 = 0; i2 < dimension[0]; i2++) {
-                    shape1[i1][i2] = Strings.repeat("b", dimension[1]);
-                }
-                shape1[i1][dimension[0]] = Strings.repeat("f", dimension[1]);
-            }
-            b.addShape(solidPrefix + i, shape1);
-        }
-        Block blockMachineBeta = RailcraftBlocks.getBlockMachineBeta();
-        Block blockAltar = ModBlocks.blockAltar;
-        IStructureDefinition<TEAltar> structureBoiler = b
-            .addElement('f', ofBlock(blockAltar,0))
-            .addElement(
-                'b',
-                partitionBy(
-                    (t, i) -> ChannelDataAccessor.getChannelData(i, "boiler") <= 1,
-                    ImmutableMap.of(
-                        true,
-                        ofBlock(blockMachineBeta, EnumMachineBeta.BOILER_TANK_LOW_PRESSURE.ordinal()),
-                        false,
-                        ofBlock(
-                            blockMachineBeta,
-                            EnumMachineBeta.BOILER_TANK_HIGH_PRESSURE.ordinal()))))
+    private static void registerAltarStructureInfo() {
+        StructureDefinition.Builder<TEAltar> altarBuilder = IStructureDefinition.builder();
+        String T6_S = "                       ";
+        String T6_SR = "r                     r";
+        // region Structure
+        // spotless:off
+        IStructureDefinition<TEAltar> structureAltar = altarBuilder
+            .addShape(STRUCTURE_ALTAR, new String[][] {{"a"}})
+            .addShape(STRUCTURE_TIER_2, transpose(new String[][] {{"rrr","r r","rrr"}}))
+            .addShape(STRUCTURE_TIER_3, transpose(new String[][] {{"g     g","       ","       ","       ","       ","       ","g     g"},
+                                                        {"t     t","       ","       ","       ","       ","       ","t     t"},
+                                                        {"t     t","       ","       ","       ","       ","       ","t     t"},
+                                                        {" rrrrr ","r     r","r     r","r     r","r     r","r     r"," rrrrr "}}))
+            .addShape(STRUCTURE_TIER_4, transpose(new String[][]
+                {{"b         b","           ","           ","           ","           ","           ","           ","           ","           ","           ","b         b"},
+                 {"v         v","           ","           ","           ","           ","           ","           ","           ","           ","           ","v         v"},
+                 {"v         v","           ","           ","           ","           ","           ","           ","           ","           ","           ","v         v"},
+                 {"v         v","           ","           ","           ","           ","           ","           ","           ","           ","           ","v         v"},
+                 {"v         v","           ","           ","           ","           ","           ","           ","           ","           ","           ","v         v"},
+                 {"  rrrrrrr  ","           ","r         r","r         r","r         r","r         r","r         r","r         r","r         r","           ","  rrrrrrr  "}}))
+            .addShape(STRUCTURE_TIER_5, transpose(new String[][] {{"e               e","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","                 ","e               e"},
+                {"  rrrrrrrrrrrrr  ","                 ","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","r               r","                 ","  rrrrrrrrrrrrr  "}}))
+            .addShape(STRUCTURE_TIER_6, transpose(new String[][]
+                {
+                    {"c                     c",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"c                     c"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"i                     i",T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,T6_S,"i                     i"},
+                    {"  rrrrrrrrrrrrrrrrrrr  ",T6_S,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_SR,T6_S, "  rrrrrrrrrrrrrrrrrrr  "},
+                }))
+            .addElement('a',ofBlock(ModBlocks.blockAltar,0))
+            .addElement('r',ofChain(ofBlockAnyMeta(ModBlocks.bloodRune),ofBlockAnyMeta(ModBlocks.speedRune),ofBlockAnyMeta(ModBlocks.runeOfSelfSacrifice),ofBlockAnyMeta(ModBlocks.runeOfSacrifice),ofBlockAnyMeta(ModBlocks.efficiencyRune)))
+            .addElement('g',ofBlock(AlchemicalWizardry.specialAltarBlock[1].getBlock(),0))
+            .addElement('t',ofBlock(AlchemicalWizardry.specialAltarBlock[0].getBlock(),0))
+            .addElement('b',ofBlock(AlchemicalWizardry.specialAltarBlock[3].getBlock(),0))
+            .addElement('v',ofBlock(AlchemicalWizardry.specialAltarBlock[2].getBlock(),0))
+            .addElement('e',ofBlock(AlchemicalWizardry.specialAltarBlock[4].getBlock(),0))
+            .addElement('c',ofBlock(AlchemicalWizardry.specialAltarBlock[6].getBlock(),0))
+            .addElement('i',ofBlock(AlchemicalWizardry.specialAltarBlock[5].getBlock(),0))
             .build();
         IMultiblockInfoContainer.registerTileClass(
             TEAltar.class,
-            new CompatBloodMagic.AltarMultiblockInfoContainer(structureBoiler, solidPrefix));
+            new CompatBloodMagic.AltarMultiblockInfoContainer(structureAltar));
+        // spotless:on
     }
 
     private static ExtendedFacing noSideWay(ExtendedFacing aSide) {
         return aSide.getDirection().offsetY != 0 ? ExtendedFacing.DEFAULT : aSide;
     }
 
-    private static class SimpleMultiblockInfoContainer<T extends TileEntity> implements IMultiblockInfoContainer<T>
-    {
+    private static class AltarMultiblockInfoContainer implements IMultiblockInfoContainer<TEAltar> {
 
-        public static final String MAIN_PIECE_NAME = "main";
-        private final IStructureDefinition<? super T> structrue;
-        private final String[] desc; // TODO somehow retranslate these at resource reload
-        private final int offsetA, offsetB, offsetC;
-        private final boolean allowSideway;
+        private final IStructureDefinition<TEAltar> structureAltar;
 
-        public SimpleMultiblockInfoContainer(IStructureDefinition<? super T> structrue, int offsetA, int offsetB,
-                                             int offsetC, String... desc) {
-            this(structrue, offsetA, offsetB, offsetC, false, desc);
-        }
-
-        public SimpleMultiblockInfoContainer(IStructureDefinition<? super T> structrue, int offsetA, int offsetB,
-                                             int offsetC, boolean allowSideway, String... desc) {
-            this.structrue = structrue;
-            this.allowSideway = allowSideway;
-            this.desc = desc;
-            this.offsetA = offsetA;
-            this.offsetB = offsetB;
-            this.offsetC = offsetC;
+        public AltarMultiblockInfoContainer(IStructureDefinition<TEAltar> structureAltar) {
+            this.structureAltar = structureAltar;
         }
 
         @Override
-        public void construct(ItemStack stackSize, boolean hintsOnly, T ctx, ExtendedFacing aSide) {
-            structrue.buildOrHints(
-                ctx,
-                stackSize,
-                MAIN_PIECE_NAME,
-                ctx.getWorldObj(),
-                allowSideway ? aSide : noSideWay(aSide),
-                ctx.xCoord,
-                ctx.yCoord,
-                ctx.zCoord,
-                offsetA,
-                offsetB,
-                offsetC,
-                hintsOnly);
-        }
-
-        @Override
-        public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env, T ctx,
-                                     ExtendedFacing aSide) {
-            return structrue.survivalBuild(
-                ctx,
-                stackSize,
-                MAIN_PIECE_NAME,
-                ctx.getWorldObj(),
-                allowSideway ? aSide : noSideWay(aSide),
-                ctx.xCoord,
-                ctx.yCoord,
-                ctx.zCoord,
-                offsetA,
-                offsetB,
-                offsetC,
-                elementBudge,
-                env,
-                false);
-        }
-
-        @Override
-        public String[] getDescription(ItemStack stackSize) {
-            return desc;
-        }
-    }
-
-    private static class AltarMultiblockInfoContainer implements IMultiblockInfoContainer<TEAltar>
-    {
-
-        private final IStructureDefinition<TEAltar> structureBoiler;
-        private final String piecePrefix;
-
-        public AltarMultiblockInfoContainer(IStructureDefinition<TEAltar> structureBoiler,
-                                             String piecePrefix) {
-            this.structureBoiler = structureBoiler;
-            this.piecePrefix = piecePrefix;
-        }
-
-        @Override
-        public void construct(ItemStack stackSize, boolean hintsOnly, TEAltar ctx, ExtendedFacing aSide) {
-            int width = ChannelDataAccessor.getChannelData(stackSize, "width"),
-                height = ChannelDataAccessor.getChannelData(stackSize, "height");
-            for (int i = 0, boilerDimensionsLength = BOILER_DIMENSIONS.length; i < boilerDimensionsLength; i++) {
-                int[] dimension = BOILER_DIMENSIONS[i];
-                if (dimension[0] == width && dimension[1] == height) {
-                    structureBoiler.buildOrHints(
+        public void construct(ItemStack triggerStack, boolean hintsOnly, TEAltar ctx, ExtendedFacing aSide) {
+            int tier = triggerStack.stackSize;
+            if (tier > 6) {
+                tier = 6;
+            }
+            for (int i = 1; i <= tier; i++) {
+                System.out.println("tier" + i);
+                this.structureAltar.buildOrHints(
                         ctx,
-                        stackSize,
-                        piecePrefix + i,
+                        triggerStack,
+                        "tier" + i,
                         ctx.getWorldObj(),
                         noSideWay(aSide),
                         ctx.xCoord,
                         ctx.yCoord,
                         ctx.zCoord,
-                        width / 2,
-                        height,
-                        0,
+                        TIER_OFFSET[i - 1][0],
+                        TIER_OFFSET[i - 1][1],
+                        TIER_OFFSET[i - 1][2],
                         hintsOnly);
-                    return;
-                }
             }
         }
 
         @Override
-        public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env,
-                                     TEAltar ctx, ExtendedFacing aSide) {
-            int width = ChannelDataAccessor.getChannelData(stackSize, "width"),
-                height = ChannelDataAccessor.getChannelData(stackSize, "height");
-            for (int i = 0, boilerDimensionsLength = BOILER_DIMENSIONS.length; i < boilerDimensionsLength; i++) {
-                int[] dimension = BOILER_DIMENSIONS[i];
-                if (dimension[0] == width && dimension[1] == height) {
-                    return structureBoiler.survivalBuild(
+        public int survivalConstruct(ItemStack triggerStack, int elementBudge, ISurvivalBuildEnvironment env,
+                TEAltar ctx, ExtendedFacing aSide) {
+            int built = 0;
+            int tier = triggerStack.stackSize;
+            if (tier > 6) {
+                tier = 6;
+            }
+            for (int i = 1; i <= tier; i++) {
+                built += this.structureAltar.survivalBuild(
                         ctx,
-                        stackSize,
-                        piecePrefix + i,
+                        triggerStack,
+                        "tier" + i,
                         ctx.getWorldObj(),
                         noSideWay(aSide),
                         ctx.xCoord,
                         ctx.yCoord,
                         ctx.zCoord,
-                        width / 2,
-                        height,
-                        0,
+                        TIER_OFFSET[i - 1][0],
+                        TIER_OFFSET[i - 1][1],
+                        TIER_OFFSET[i - 1][2],
                         elementBudge,
                         env,
                         false);
-                }
             }
-            env.getActor().addChatMessage(
-                new ChatComponentTranslation(
-                    "structureinfo.railcraft.boiler.error.invalid_dimension",
-                    width,
-                    height));
-            return -1;
+            return built;
         }
 
         @Override
         public String[] getDescription(ItemStack stackSize) {
-            return new String[] { StatCollector.translateToLocal("structureinfo.railcraft.boiler.0"),
-                StatCollector.translateToLocal("structureinfo.railcraft.boiler.1"),
-                StatCollector.translateToLocal("structureinfo.railcraft.boiler.2"),
-                StatCollector.translateToLocal("structureinfo.railcraft.boiler.3"),
-                StatCollector.translateToLocal("structureinfo.railcraft.boiler.4"),
-                StatCollector.translateToLocal("structureinfo.railcraft.boiler.5"), };
+            return new String[] { StatCollector.translateToLocal("structureinfo.bloodmagic.altar.1"),
+                    StatCollector.translateToLocal("structureinfo.bloodmagic.altar.2") };
         }
     }
-
 }

--- a/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
+++ b/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
@@ -1,0 +1,230 @@
+package net.glease.structurecompat;
+
+import WayofTime.alchemicalWizardry.ModBlocks;
+import WayofTime.alchemicalWizardry.common.tileEntity.TEAltar;
+
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.ofBlock;
+import static com.gtnewhorizon.structurelib.structure.StructureUtility.partitionBy;
+
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.StatCollector;
+
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizon.structurelib.alignment.constructable.ChannelDataAccessor;
+import com.gtnewhorizon.structurelib.alignment.constructable.IMultiblockInfoContainer;
+import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+
+import mods.railcraft.common.blocks.RailcraftBlocks;
+import mods.railcraft.common.blocks.machine.beta.EnumMachineBeta;
+
+
+@Compat("AWWayofTime")
+public class CompatBloodMagic
+{
+    // (width, height)
+    public static final int[][] BOILER_DIMENSIONS = { { 1, 1 }, { 2, 2 }, { 2, 3 }, { 3, 2 }, { 3, 3 }, { 3, 4 } };
+
+    public CompatBloodMagic()
+    {
+        registerBoilerStructureInfo();
+    }
+
+    private static void registerBoilerStructureInfo() {
+        String solidPrefix = "st";
+        StructureDefinition.Builder<TEAltar> b = IStructureDefinition.builder();
+        int[][] ints = BOILER_DIMENSIONS;
+        for (int i = 0, intsLength = ints.length; i < intsLength; i++) {
+            int[] dimension = ints[i];
+            String[][] shape1 = new String[dimension[1]][];
+            for (int i1 = 0; i1 < dimension[1]; i1++) {
+                shape1[i1] = new String[dimension[0] + 1];
+                for (int i2 = 0; i2 < dimension[0]; i2++) {
+                    shape1[i1][i2] = Strings.repeat("b", dimension[1]);
+                }
+                shape1[i1][dimension[0]] = Strings.repeat("f", dimension[1]);
+            }
+            b.addShape(solidPrefix + i, shape1);
+        }
+        Block blockMachineBeta = RailcraftBlocks.getBlockMachineBeta();
+        Block blockAltar = ModBlocks.blockAltar;
+        IStructureDefinition<TEAltar> structureBoiler = b
+            .addElement('f', ofBlock(blockAltar,0))
+            .addElement(
+                'b',
+                partitionBy(
+                    (t, i) -> ChannelDataAccessor.getChannelData(i, "boiler") <= 1,
+                    ImmutableMap.of(
+                        true,
+                        ofBlock(blockMachineBeta, EnumMachineBeta.BOILER_TANK_LOW_PRESSURE.ordinal()),
+                        false,
+                        ofBlock(
+                            blockMachineBeta,
+                            EnumMachineBeta.BOILER_TANK_HIGH_PRESSURE.ordinal()))))
+            .build();
+        IMultiblockInfoContainer.registerTileClass(
+            TEAltar.class,
+            new CompatBloodMagic.AltarMultiblockInfoContainer(structureBoiler, solidPrefix));
+    }
+
+    private static ExtendedFacing noSideWay(ExtendedFacing aSide) {
+        return aSide.getDirection().offsetY != 0 ? ExtendedFacing.DEFAULT : aSide;
+    }
+
+    private static class SimpleMultiblockInfoContainer<T extends TileEntity> implements IMultiblockInfoContainer<T>
+    {
+
+        public static final String MAIN_PIECE_NAME = "main";
+        private final IStructureDefinition<? super T> structrue;
+        private final String[] desc; // TODO somehow retranslate these at resource reload
+        private final int offsetA, offsetB, offsetC;
+        private final boolean allowSideway;
+
+        public SimpleMultiblockInfoContainer(IStructureDefinition<? super T> structrue, int offsetA, int offsetB,
+                                             int offsetC, String... desc) {
+            this(structrue, offsetA, offsetB, offsetC, false, desc);
+        }
+
+        public SimpleMultiblockInfoContainer(IStructureDefinition<? super T> structrue, int offsetA, int offsetB,
+                                             int offsetC, boolean allowSideway, String... desc) {
+            this.structrue = structrue;
+            this.allowSideway = allowSideway;
+            this.desc = desc;
+            this.offsetA = offsetA;
+            this.offsetB = offsetB;
+            this.offsetC = offsetC;
+        }
+
+        @Override
+        public void construct(ItemStack stackSize, boolean hintsOnly, T ctx, ExtendedFacing aSide) {
+            structrue.buildOrHints(
+                ctx,
+                stackSize,
+                MAIN_PIECE_NAME,
+                ctx.getWorldObj(),
+                allowSideway ? aSide : noSideWay(aSide),
+                ctx.xCoord,
+                ctx.yCoord,
+                ctx.zCoord,
+                offsetA,
+                offsetB,
+                offsetC,
+                hintsOnly);
+        }
+
+        @Override
+        public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env, T ctx,
+                                     ExtendedFacing aSide) {
+            return structrue.survivalBuild(
+                ctx,
+                stackSize,
+                MAIN_PIECE_NAME,
+                ctx.getWorldObj(),
+                allowSideway ? aSide : noSideWay(aSide),
+                ctx.xCoord,
+                ctx.yCoord,
+                ctx.zCoord,
+                offsetA,
+                offsetB,
+                offsetC,
+                elementBudge,
+                env,
+                false);
+        }
+
+        @Override
+        public String[] getDescription(ItemStack stackSize) {
+            return desc;
+        }
+    }
+
+    private static class AltarMultiblockInfoContainer implements IMultiblockInfoContainer<TEAltar>
+    {
+
+        private final IStructureDefinition<TEAltar> structureBoiler;
+        private final String piecePrefix;
+
+        public AltarMultiblockInfoContainer(IStructureDefinition<TEAltar> structureBoiler,
+                                             String piecePrefix) {
+            this.structureBoiler = structureBoiler;
+            this.piecePrefix = piecePrefix;
+        }
+
+        @Override
+        public void construct(ItemStack stackSize, boolean hintsOnly, TEAltar ctx, ExtendedFacing aSide) {
+            int width = ChannelDataAccessor.getChannelData(stackSize, "width"),
+                height = ChannelDataAccessor.getChannelData(stackSize, "height");
+            for (int i = 0, boilerDimensionsLength = BOILER_DIMENSIONS.length; i < boilerDimensionsLength; i++) {
+                int[] dimension = BOILER_DIMENSIONS[i];
+                if (dimension[0] == width && dimension[1] == height) {
+                    structureBoiler.buildOrHints(
+                        ctx,
+                        stackSize,
+                        piecePrefix + i,
+                        ctx.getWorldObj(),
+                        noSideWay(aSide),
+                        ctx.xCoord,
+                        ctx.yCoord,
+                        ctx.zCoord,
+                        width / 2,
+                        height,
+                        0,
+                        hintsOnly);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env,
+                                     TEAltar ctx, ExtendedFacing aSide) {
+            int width = ChannelDataAccessor.getChannelData(stackSize, "width"),
+                height = ChannelDataAccessor.getChannelData(stackSize, "height");
+            for (int i = 0, boilerDimensionsLength = BOILER_DIMENSIONS.length; i < boilerDimensionsLength; i++) {
+                int[] dimension = BOILER_DIMENSIONS[i];
+                if (dimension[0] == width && dimension[1] == height) {
+                    return structureBoiler.survivalBuild(
+                        ctx,
+                        stackSize,
+                        piecePrefix + i,
+                        ctx.getWorldObj(),
+                        noSideWay(aSide),
+                        ctx.xCoord,
+                        ctx.yCoord,
+                        ctx.zCoord,
+                        width / 2,
+                        height,
+                        0,
+                        elementBudge,
+                        env,
+                        false);
+                }
+            }
+            env.getActor().addChatMessage(
+                new ChatComponentTranslation(
+                    "structureinfo.railcraft.boiler.error.invalid_dimension",
+                    width,
+                    height));
+            return -1;
+        }
+
+        @Override
+        public String[] getDescription(ItemStack stackSize) {
+            return new String[] { StatCollector.translateToLocal("structureinfo.railcraft.boiler.0"),
+                StatCollector.translateToLocal("structureinfo.railcraft.boiler.1"),
+                StatCollector.translateToLocal("structureinfo.railcraft.boiler.2"),
+                StatCollector.translateToLocal("structureinfo.railcraft.boiler.3"),
+                StatCollector.translateToLocal("structureinfo.railcraft.boiler.4"),
+                StatCollector.translateToLocal("structureinfo.railcraft.boiler.5"), };
+        }
+    }
+
+}

--- a/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
+++ b/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
@@ -84,7 +84,7 @@ public class CompatBloodMagic {
             new CompatBloodMagic.AltarMultiblockInfoContainer(structureAltar));
         // spotless:on
     }
-    
+
     private static class AltarMultiblockInfoContainer implements IMultiblockInfoContainer<TEAltar> {
 
         private final IStructureDefinition<TEAltar> structureAltar;

--- a/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
+++ b/src/main/java/net/glease/structurecompat/CompatBloodMagic.java
@@ -21,12 +21,12 @@ import WayofTime.alchemicalWizardry.common.tileEntity.TEAltar;
 @Compat("AWWayofTime")
 public class CompatBloodMagic {
 
-    private static String STRUCTURE_ALTAR = "tier1";
-    private static String STRUCTURE_TIER_2 = "tier2";
-    private static String STRUCTURE_TIER_3 = "tier3";
-    private static String STRUCTURE_TIER_4 = "tier4";
-    private static String STRUCTURE_TIER_5 = "tier5";
-    private static String STRUCTURE_TIER_6 = "tier6";
+    private static final String STRUCTURE_ALTAR = "tier1";
+    private static final String STRUCTURE_TIER_2 = "tier2";
+    private static final String STRUCTURE_TIER_3 = "tier3";
+    private static final String STRUCTURE_TIER_4 = "tier4";
+    private static final String STRUCTURE_TIER_5 = "tier5";
+    private static final String STRUCTURE_TIER_6 = "tier6";
 
     public static final int[][] TIER_OFFSET = { { 0, 0, 0 }, { 1, -1, 1 }, { 3, 1, 3 }, { 5, 2, 5 }, { 8, -3, 8 },
             { 11, 3, 11 } };
@@ -84,11 +84,7 @@ public class CompatBloodMagic {
             new CompatBloodMagic.AltarMultiblockInfoContainer(structureAltar));
         // spotless:on
     }
-
-    private static ExtendedFacing noSideWay(ExtendedFacing aSide) {
-        return aSide.getDirection().offsetY != 0 ? ExtendedFacing.DEFAULT : aSide;
-    }
-
+    
     private static class AltarMultiblockInfoContainer implements IMultiblockInfoContainer<TEAltar> {
 
         private final IStructureDefinition<TEAltar> structureAltar;
@@ -104,13 +100,12 @@ public class CompatBloodMagic {
                 tier = 6;
             }
             for (int i = 1; i <= tier; i++) {
-                System.out.println("tier" + i);
                 this.structureAltar.buildOrHints(
                         ctx,
                         triggerStack,
                         "tier" + i,
                         ctx.getWorldObj(),
-                        noSideWay(aSide),
+                        ExtendedFacing.DEFAULT,
                         ctx.xCoord,
                         ctx.yCoord,
                         ctx.zCoord,
@@ -129,13 +124,15 @@ public class CompatBloodMagic {
             if (tier > 6) {
                 tier = 6;
             }
+            if (ctx.getTier() >= tier) return -1;
+
             for (int i = 1; i <= tier; i++) {
                 built += this.structureAltar.survivalBuild(
                         ctx,
                         triggerStack,
                         "tier" + i,
                         ctx.getWorldObj(),
-                        noSideWay(aSide),
+                        ExtendedFacing.DEFAULT,
                         ctx.xCoord,
                         ctx.yCoord,
                         ctx.zCoord,

--- a/src/main/resources/assets/structurecompat/lang/en_US.lang
+++ b/src/main/resources/assets/structurecompat/lang/en_US.lang
@@ -6,4 +6,7 @@ structureinfo.railcraft.boiler.4=Width range: 1-3. Height range: depends on widt
 structureinfo.railcraft.boiler.5=Uses sub channel §6boiler§r§7 to specify what type of boiler to use. 
 structureinfo.railcraft.boiler.error.invalid_dimension=Width %s Height %s is not a valid combination.
 
+structureinfo.bloodmagic.altar.1=Blood Magic Altar
+structureinfo.bloodmagic.altar.2=Hold 1-6 Hologram Projectors to determine the tier
+
 structureelement.error.cannot_be_block=(%s, %s, %s) §cCANNOT§r be %s!


### PR DESCRIPTION
Lets the Hologram Projector work to view/place the blood altar structure, support tiering based on hologram projectors held
![2024-04-29_00 09 46](https://github.com/GTNewHorizons/StructureCompat/assets/8147477/be0d6f08-daf1-472f-9691-7bf84f167302)
