### PR TITLE
Update dependencies due to API Change in Forestry and GT5u

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,37 +1,37 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:StructureLib:1.4.10:dev")
+    api("com.github.GTNewHorizons:StructureLib:1.4.18:dev")
 
-    implementation("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-602-GTNH:dev") {
+    implementation("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-673-GTNH:dev") {
         transitive = false
     }
     implementation("com.github.GTNewHorizons:AdventureBackpack2:1.3.9-GTNH:dev") {
         transitive = false
     }
-    implementation("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.5.0-GTNH:dev") {
+    implementation("com.github.GTNewHorizons:Minecraft-Backpack-Mod:2.5.4-GTNH:dev") {
         transitive = false
     }
-    implementation("com.github.GTNewHorizons:ForestryMC:4.10.7:dev") {
+    implementation("com.github.GTNewHorizons:ForestryMC:4.10.17:dev") {
         transitive = false
     }
-    implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.1:dev")
-    implementation("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.65-gtnh:dev") {
+    implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.7:dev")
+    implementation("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.108-gtnh:dev") {
         exclude module: 'Baubles'
     }
     // or else wct compat won't compile
     implementation("curse.maven:cofh-core-69162:2388751") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.6.53:dev") {
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.6.98:dev") {
         transitive = false
     }
-    implementation("com.github.GTNewHorizons:Railcraft:9.16.28:dev") {
+    implementation("com.github.GTNewHorizons:Railcraft:9.16.32:dev") {
         exclude module: 'Baubles'
     }
-    implementation("com.github.GTNewHorizons:Baubles-Expanded:2.1.7-GTNH:dev")
+    implementation("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev")
 
     // for convenience of debug
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.44-GTNH:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.4:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.72-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.8.12:dev")
 }


### PR DESCRIPTION
Forestry API Changed in the never versions so if you require the newest GT5u and depend on StructureCompat then you will run into issues (BlockRenderer requires on both GT5u and NEE)